### PR TITLE
copy only newer files

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var minifyJS   = require( 'gulp-uglify' ) ,
     minifyCSS  = require( 'gulp-minify-css' ) ,
-    minifyHTML = require( 'gulp-htmlmin' );
+    minifyHTML = require( 'gulp-htmlmin' ) ,
+    newer      = require('gulp-newer') ;
 
 module.exports = main;
 
@@ -84,6 +85,7 @@ function main( gulp , options ) {
 
     function copy( path , myDest ) {
         return gulp.src( path || copyFiles )
+            .pipe(newer( myDest || dest ))
             .pipe( gulp.dest( myDest || dest ) );
     }
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies" : {
     "gulp-uglify" : "^1.2.0" ,
     "gulp-minify-css" : "^1.2.0" ,
-    "gulp-htmlmin" : "^1.1.3"
+    "gulp-htmlmin" : "^1.1.3",
+    "gulp-newer" : "^1.3.0"
   }
 }


### PR DESCRIPTION
Added gulp-newer dependency and changed copy task to only copy newer
files. This allows for chaining with gulp-rsync. Without it, all files are new and rsync copies things that don't need to be copied, which is painful on slow connections.